### PR TITLE
removing conda env stress from workflow - 3.7 & 3.11 testing only. 

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, "3.11"]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
Github conda env is unstable and does not have the same maximums as pip based env. Will test only 3.7 and 3.11. If it passed those 2 python versions its safe enough to assume they will work for each version inbetween. 