### PR TITLE
Development

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,6 +8,7 @@ on:
     branches: ["main", "development"]
 jobs:
   pytest:
+    if: always()
     name: Ex1 ${{ matrix.python-version }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     defaults:
@@ -17,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.7, "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,10 +28,6 @@ jobs:
           activate-environment: imagetocsv
           environment-file: environment.yml
           auto-activate-base: false
-      # Needed for python 3.7 only
-      - name: Install dependencies (linux)
-        if: runner.os == 'Linux'
-        run: sudo apt install --yes libpoppler-cpp-dev pkg-config tesseract-ocr libtesseract-dev
       - name: Install dependencies
         run: pip install --no-cache-dir ".[dev]"  # opencv known for cache issues
       - name: Unit Testing

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: imagetocsv
 channels:
   - conda-forge
 dependencies:
-  - python>=3.7
+  - python>=3.10
   - pip
   - poppler==22.11.0
   - tesseract==5.2.0


### PR DESCRIPTION
#6 Demonstrates that the env allowing Python>=3.7 will favor older versions with core dep. issues. Updating default Python to be >=3.10