### PR TITLE
C and C++ compilers per OS

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,10 +31,10 @@ jobs:
       # Needed for python 3.7 only
       - name: Install dependencies (linux)
         if: runner.os == 'Linux'
-        run: conda install -y gcc gxx
+        run: conda install -y -c conda-forge gcc_linux-64 gxx_linux-64
       - name: Install dependencies (macos)
         if: runner.os == 'macos'
-        run: conda install -y clang_osx-64 clangxx_osx-64
+        run: conda install -y -c conda-forge clang_osx-64 clangxx_osx-64
       - name: Install dependencies
         run: pip install --no-cache-dir ".[dev]"  # opencv known for cache issues
       - name: Unit Testing

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
@@ -28,6 +28,13 @@ jobs:
           activate-environment: imagetocsv
           environment-file: environment.yml
           auto-activate-base: false
+      # Needed for python 3.7 only
+      - name: Install dependencies (linux)
+        if: runner.os == 'Linux'
+        run: conda install -y gcc gxx
+      - name: Install dependencies (macos)
+        if: runner.os == 'macos'
+        run: conda install -y clangxx_osx-64
       - name: Install dependencies
         run: pip install --no-cache-dir ".[dev]"  # opencv known for cache issues
       - name: Unit Testing

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,7 +33,7 @@ jobs:
         if: runner.os == 'Linux'
         run: conda install -y -c conda-forge gcc_linux-64 gxx_linux-64
       - name: Install dependencies (macos)
-        if: runner.os == 'macos'
+        if: runner.os == 'macOS'
         run: conda install -y -c conda-forge clang_osx-64 clangxx_osx-64
       - name: Install dependencies
         run: pip install --no-cache-dir ".[dev]"  # opencv known for cache issues

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
@@ -34,7 +34,7 @@ jobs:
         run: conda install -y gcc gxx
       - name: Install dependencies (macos)
         if: runner.os == 'macos'
-        run: conda install -y clangxx_osx-64
+        run: conda install -y clang_osx-64 clangxx_osx-64
       - name: Install dependencies
         run: pip install --no-cache-dir ".[dev]"  # opencv known for cache issues
       - name: Unit Testing

--- a/README.md
+++ b/README.md
@@ -68,21 +68,40 @@ Conda does not install all needed packages for Python 3.7 so you need to install
 sudo apt install --yes build-essential libpoppler-cpp-dev pkg-config tesseract-ocr libtesseract-dev
 ```
 
-# Installation
+# Installation MacOS
 
 ```bash
-conda create -n imagetocsv -f environment.yml
+conda create -n imagetocsv pip python=3.11.6
 conda activate imagetocsv
+conda install -y -c conda-forge clang_osx-64 clangxx_osx-64 poppler==22.11.0 tesseract==5.2.0
+pip install imagetocsv
+```
+
+# Installation Linux
+
+```bash
+conda create -n imagetocsv pip python=3.11.6
+conda activate imagetocsv
+conda install -y -c conda-forge gcc gxx poppler==22.11.0 tesseract==5.2.0
+pip install imagetocsv
+```
+
+# Installation Windows 10/11
+
+### Note that this is untested and may not work if you do not have a C++ compiler installed.
+
+```bash
+conda create -n imagetocsv pip python=3.11.6
+conda activate imagetocsv
+conda install -y -c conda-forge poppler==22.11.0 tesseract==5.2.0
 pip install imagetocsv
 ```
 
 # Development
 
-## Conda environment
+## Pip install cloned repo
 
 ```bash
-conda create -n imagetocsv -f environment.yml
-conda activate imagetocsv
 pip install -e ".[dev]"
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pip install imagetocsv
 ```bash
 conda create -n imagetocsv pip python=3.11.6
 conda activate imagetocsv
-conda install -y -c conda-forge gcc gxx poppler==22.11.0 tesseract==5.2.0
+conda install -y -c conda-forge gcc_linux-64 gxx_linux-64 poppler==22.11.0 tesseract==5.2.0
 pip install imagetocsv
 ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,5 @@ channels:
 dependencies:
   - python>=3.10
   - pip
-  - gcc
-  - gxx
   - poppler==22.11.0
   - tesseract==5.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -5,5 +5,6 @@ dependencies:
   - python>=3.10
   - pip
   - gcc
+  - gxx
   - poppler==22.11.0
   - tesseract==5.2.0


### PR DESCRIPTION
MacOS needs: `clang_osx-64 clangxx_osx-64`
Linux needs: `gcc_linux-64 gxx_linux-64`
Windows expected to have core compilers.